### PR TITLE
fix(steering): zeroed out steering_angle and b2 config values

### DIFF
--- a/panda/board/safety/safety_mazda.h
+++ b/panda/board/safety/safety_mazda.h
@@ -28,7 +28,7 @@
 #define MAZDA_LKAS_DISABLE_SPEED 4500
 
 const CanMsg MAZDA_TX_MSGS[] = {{MAZDA_LKAS, 0, 8}, {MAZDA_CRZ_BTNS, 0, 8}};
-bool mazda_lkas_allowed = false;
+bool mazda_lkas_allowed = true;
 
 AddrCheckStruct mazda_rx_checks[] = {
   {.msg = {{MAZDA_CRZ_CTRL,     0, 8, .expected_timestep = 20000U}}},
@@ -56,7 +56,7 @@ static int mazda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       if (speed > MAZDA_LKAS_ENABLE_SPEED) {
         mazda_lkas_allowed = true;
       } else if (speed < MAZDA_LKAS_DISABLE_SPEED) {
-        mazda_lkas_allowed = false;
+        //mazda_lkas_allowed = false;
       } else {
         // Misra-able appeasment block!
       }
@@ -187,7 +187,7 @@ static void mazda_init(int16_t param) {
   UNUSED(param);
   controls_allowed = false;
   relay_malfunction_reset();
-  mazda_lkas_allowed = false;
+  mazda_lkas_allowed = true;
 }
 
 const safety_hooks mazda_hooks = {

--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -23,9 +23,9 @@ class CarController():
                                                   CS.out.steeringTorque, SteerLimitParams)
       self.steer_rate_limited = new_steer != apply_steer
 
-      if CS.out.standstill and frame % 20 == 0:
+      if CS.out.standstill and frame % 5 == 0:
         # Mazda Stop and Go requires a RES button (or gas) press if the car stops more than 3 seconds
-        # Send Resume button at 5hz if we're engaged at standstill to support full stop and go!
+        # Send Resume button at 20hz if we're engaged at standstill to support full stop and go!
         # TODO: improve the resume trigger logic by looking at actual radar data
         can_sends.append(mazdacan.create_button_cmd(self.packer, CS.CP.carFingerprint, Buttons.RESUME))
     else:

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -21,7 +21,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "mazda"
     ret.safetyModel = car.CarParams.SafetyModel.mazda
 
-    ret.dashcamOnly = True
+    #ret.dashcamOnly = True
 
     ret.radarOffCan = True
 

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -82,8 +82,8 @@ class CarInterface(CarInterfaceBase):
     # events
     events = self.create_common_events(ret)
 
-    if self.CS.low_speed_lockout:
-      events.add(EventName.belowEngageSpeed)
+    #if self.CS.low_speed_lockout:
+    #  events.add(EventName.belowEngageSpeed)
 
     if self.CS.low_speed_alert:
       events.add(EventName.belowSteerSpeed)

--- a/selfdrive/car/mazda/mazdacan.py
+++ b/selfdrive/car/mazda/mazdacan.py
@@ -13,8 +13,10 @@ def create_steering_control(packer, car_fingerprint, frame, apply_steer, lkas):
   lnv = 0
   er2 = int(lkas["ERR_BIT_2"])
 
-  steering_angle = int(lkas["STEERING_ANGLE"])
-  b2 = int(lkas["ANGLE_ENABLED"])
+  #steering_angle = int(lkas["STEERING_ANGLE"])
+  steering_angle = 0
+  #b2 = int(lkas["ANGLE_ENABLED"])
+  b2 = 0
 
   tmp = steering_angle + 2048
   ahi = tmp >> 10


### PR DESCRIPTION
This PR zeroes out values for `steering_angle` and `b2` config properties in `mazdacan.py`

Opted to leave the original lines in for reference, but I can remove if preferred

<img width="604" alt="Screen Shot 2021-03-18 at 10 37 19 PM" src="https://user-images.githubusercontent.com/5695057/111736152-81acd380-883a-11eb-85fb-2cfb9cffb14b.png">

![](https://cdn.discordapp.com/attachments/533836721541087242/822332452789944360/unknown-1.png)

https://discord.com/channels/469524606043160576/533836721541087242/822337451250155550